### PR TITLE
Added trace effect of project cards outlines

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,9 @@
                                 <button><a href="#">Cached >=</a></button>
                             </div>
                         </div>
+                        <svg class="border-svg" viewBox="0 0 85 100">
+                            <path d="M0,0.3 H85 V63 H0 V52.5 H85 V100 H0 Z" />
+                        </svg>
                     </div>
                     <div class="project-card">
                         <img src="assets/projectx.png" alt="Screenshot of projects ProjectX">
@@ -92,13 +95,17 @@
                             <li>Flask</li>
                         </ul>
                         <div class="project-info">
-                            <h3>ProjectX</h3>
+                            <h3>ProtectX</h3>
                             <p>Discord anti-crash bot</p>
                             <div class="project-links">
                                 <button><a href="#">Live <~></a></button>
                                 <button><a href="#">Cached >=</a></button>
                             </div>
                         </div>
+                        <svg class="border-svg projectX" viewBox="0 0 99 123">
+                            <path d="M49.5,0 H0 V80 H98.5 V123 H0 V0" />
+                            <path d="M49.5,0 H98.5 V60 H0 V123 H98.5 V58" />
+                        </svg>
                     </div>
                     <div class="project-card">
                         <img src="assets/kahoot.png" alt="Screenshot of projects Kahoot">
@@ -115,6 +122,9 @@
                                 <button><a href="#">Cached >=</a></button>
                             </div>
                         </div>
+                        <svg class="border-svg" viewBox="0 0 85 100">
+                            <path d="M0,0.3 H85 V52.5 H0 V63 H85 V52.5 V100 H0 Z" />
+                        </svg>
                     </div>
                 </div>
             </section>

--- a/style.css
+++ b/style.css
@@ -239,7 +239,7 @@ header {
     gap: 8px;
 }
 
-/* Projects seciton */
+/* Projects section */
 .projects {
     display: flex;
     flex-direction: column;
@@ -298,12 +298,47 @@ header {
 }
 
 .project-card, .project-card img {
+    position: relative;
     border: 1px solid var(--gray);
+    overflow: hidden;
 }
 .project-card img {
     width: 100%;
     object-fit: cover;
     box-sizing: border-box;
+}
+
+.border-svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    
+}
+
+.border-svg path {
+    fill: none;
+    stroke: var(--trace);
+    stroke-width: 0.5;
+    stroke-dasharray: 560;
+    stroke-dashoffset: 560;
+    transition: stroke-dashoffset 0.5s linear;
+    z-index: 10;
+}
+
+@media (max-width: 1024px) and (min-width: 400px) {
+    .border-svg {
+        display: none;
+    }
+    .border-svg path {
+        stroke-width: 0;
+    }
+}
+
+.project-card:hover .border-svg path {
+    stroke-dashoffset: 0;
 }
 
 .project-card ul {

--- a/theme.css
+++ b/theme.css
@@ -2,5 +2,6 @@
     --primary: #C778DD;
     --gray: #ABB2BF;
     --background: #282C33;
-    --white: #FFFFFF
+    --white: #FFFFFF;
+    --trace: #E6A4F8;
 }


### PR DESCRIPTION
This pull request implements a hover effect on the portfolio projects cards. It includes updates to the:
- index.html, 
- style.css and 
- theme.css
files.

These updates combine to give the effect of a trace along the border/outline of each "project card" (projects section) on hover. This is meant to both add visual interest and emphasis on the specific card hovered on.

This effect is disabled for screen sizes between 400px and 1024px since the trace aligns best with card borders for screens outside this range.

The image below shows the CherrNodes card on hover.
![CherNodes-outline-trace](https://github.com/user-attachments/assets/76deb2bb-44b5-4463-8cb6-64ccbc0acbd5)
